### PR TITLE
[Bug](fix) Init IMAGE_TOOL parameter to avoid error report #9277

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -35,7 +35,7 @@ eval set -- "$OPTS"
 RUN_DAEMON=0
 HELPER=
 IMAGE_PATH=
-IMAGE_TOOL=
+IMAGE_TOOL=0
 while true; do
     case "$1" in
     --daemon)


### PR DESCRIPTION


# Proposed changes

Issue Number: #9277

## Problem Summary:
IMAGE_TOOL is not initialized, 
`if [ ${IMAGE_TOOL} -eq 1 ]; then` 
above code report error
Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
